### PR TITLE
Adding Warm-Up time for SHTC3

### DIFF
--- a/shtc3/include/shtc3.h
+++ b/shtc3/include/shtc3.h
@@ -19,6 +19,7 @@ extern "C" {
 
 // SHTC3 I2C address
 #define SHTC3_I2C_ADDR          ((uint8_t)0x70) // I2C address of SHTC3 sensor
+#define SHTC3_WARMUP_US         (240)           // Warm-up for SHTC3 sensor in us (typical 180, max 240)
 
 // SHTC3 register addresses write only
 typedef enum {

--- a/shtc3/shtc3.c
+++ b/shtc3/shtc3.c
@@ -46,7 +46,8 @@ static esp_err_t shtc3_wake(i2c_master_dev_handle_t dev_handle)
     
     ret = i2c_master_transmit(dev_handle, read_reg, 2, -1);
     ESP_RETURN_ON_ERROR(ret, TAG, "Failed to wake up SHTC3 sensor");
-
+    esp_rom_delay_us(SHTC3_WARMUP_US); //We need some time for sensor warm-up after wake
+    
     return ret;
 }
 


### PR DESCRIPTION
This temperature and humidity sensor is included on the ESP32-C3-DEVKIT-RUST-1 as well as on Espressif’s Summit 2025 Special Edition board.

During testing, I observed that the first data read fails if the sensor was previously in power-down mode.

According to Table 5 of the [SHTC3 datasheet](https://sensirion.com/media/documents/643F9C8E/63A5A436/Datasheet_SHTC3.pdf), the wake-up command requires a minimum wait time before issuing further transactions. To comply with this requirement, we now insert a 240 µs delay after sending the wake-up command.

<img width="1493" height="413" alt="image" src="https://github.com/user-attachments/assets/f9031fbe-dc5b-4fe2-8bb2-e10d7aa89f88" />