### PR TITLE
Added new APIs and BSP ready

### DIFF
--- a/tv-b-gone/README.md
+++ b/tv-b-gone/README.md
@@ -12,9 +12,10 @@ This project is based on the [TV-B-Gone-kit_V2](https://github.com/maltman23/TV-
 
 ## Core Responsibility
 
-The core configures and drives only the IR output hardware. Button handling,
-visible LED signaling, and any board-specific UI behavior belong in the
-application or example code.
+The core drives IR transmission and send lifecycle. It can either create and
+own its own RMT TX channel or borrow a channel that was already created by a
+BSP or another component. Button handling, visible LED signaling, and any
+board-specific UI behavior belong in the application or example code.
 
 ## Public API
 
@@ -24,10 +25,26 @@ application or example code.
 tvbgone_core_config_t config;
 tvbgone_core_get_default_config(&config);
 config.ir_led_gpio = GPIO_NUM_2;
+config.rmt_channel_mode = TVBGONE_CORE_RMT_CHANNEL_MODE_INTERNAL;
 
 ESP_ERROR_CHECK(tvbgone_core_init(&config));
+tvbgone_core_status_t status;
+ESP_ERROR_CHECK(tvbgone_core_get_status(&status));
 ESP_ERROR_CHECK(tvbgone_core_send(TVBGONE_CORE_REGION_NA,
                                   TVBGONE_CORE_SEND_MODE_SINGLE));
+```
+
+For BSP-owned RMT, pass the pre-created channel handle instead:
+
+```c
+rmt_channel_handle_t bsp_ir_channel = /* created and enabled by BSP */;
+
+tvbgone_core_config_t config;
+tvbgone_core_get_default_config(&config);
+config.rmt_channel_mode = TVBGONE_CORE_RMT_CHANNEL_MODE_BORROWED;
+config.external_rmt_channel = bsp_ir_channel;
+
+ESP_ERROR_CHECK(tvbgone_core_init(&config));
 ```
 
 Available send options:
@@ -35,15 +52,26 @@ Available send options:
 - Regions: `TVBGONE_CORE_REGION_NA`, `TVBGONE_CORE_REGION_EU`, `TVBGONE_CORE_REGION_BOTH`
 - Modes: `TVBGONE_CORE_SEND_MODE_SINGLE`, `TVBGONE_CORE_SEND_MODE_CONTINUOUS`
 
+Use `tvbgone_core_get_status()` to read the current run state, requested region,
+active code number, and total code count for the current or most recent send.
+
 Use `tvbgone_core_stop()` to interrupt an in-flight single sweep or stop a
 continuous send loop. Use `tvbgone_core_deinit()` when you need to tear down the
 IR hardware before reconfiguration.
 
+When using a borrowed BSP-owned channel, `tvbgone_core_deinit()` only releases
+resources created by `tvbgone_core` itself. The external channel must already be
+created and enabled before `tvbgone_core_init()`. `tvbgone_core_stop()` still
+uses the RMT driver recovery path to interrupt an active transmission.
+
 ## Example
 
 The example in [`examples/tvbgone_esp32c3_supermini`](examples/tvbgone_esp32c3_supermini)
-is the reference application for this component. It keeps the board-facing
-behavior in example code:
+is the reference application for the internal-channel mode. The
+[`examples/defconsg1-badge`](examples/defconsg1-badge) example shows how to pass
+in a BSP-owned TX channel.
+
+Both examples keep the board-facing behavior in example code:
 
 - press NA to transmit the North America database
 - press EU to transmit the Europe database

--- a/tv-b-gone/examples/defconsg1-badge/README.md
+++ b/tv-b-gone/examples/defconsg1-badge/README.md
@@ -16,8 +16,10 @@ This project is based on the [TV-B-Gone-kit_V2](https://github.com/maltman23/TV-
   databases in sequence.
 - Press the button again during an active transmission to stop it.
 - Press the button again after a stopped or completed sweep to start a new one.
-- The example owns the button behavior; the core only controls the IR LED
-  output.
+- The example simulates a BSP by creating and enabling the RMT TX channel
+  itself, then passes that channel into `tvbgone_core`.
+- The example owns the button behavior and borrowed-channel setup; the core only
+  controls TV-B-Gone transmission.
 
 ## Build
 

--- a/tv-b-gone/examples/defconsg1-badge/main/main.c
+++ b/tv-b-gone/examples/defconsg1-badge/main/main.c
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 
 #include "driver/gpio.h"
+#include "driver/rmt_tx.h"
 #include "esp_check.h"
 #include "esp_err.h"
 #include "esp_log.h"
@@ -14,13 +15,17 @@
 #define TVBGONE_BUTTON_GPIO GPIO_NUM_10
 
 #define BUTTON_POLL_MS 25
+#define BSP_RMT_RESOLUTION_HZ 1000000U
+#define BSP_RMT_MEM_BLOCK_SYMBOLS 128U
 
 static const char *TAG = "defconsg1_badge";
 
 static TaskHandle_t s_send_task;
+static rmt_channel_handle_t s_bsp_ir_rmt_channel;
 static portMUX_TYPE s_send_lock = portMUX_INITIALIZER_UNLOCKED;
 
 static void dcsg1b_send_task(void *arg);
+static esp_err_t dcsg1b_init_bsp_ir_channel(void);
 
 static void dcsg1b_toggle_both_regions_send(void)
 {
@@ -84,9 +89,36 @@ static void dcsg1b_button_task(void *arg)
     }
 }
 
+static esp_err_t dcsg1b_init_bsp_ir_channel(void)
+{
+    rmt_tx_channel_config_t tx_chan_cfg = {
+        .gpio_num = TVBGONE_IR_LED_GPIO,
+        .clk_src = RMT_CLK_SRC_DEFAULT,
+        .resolution_hz = BSP_RMT_RESOLUTION_HZ,
+        .mem_block_symbols = BSP_RMT_MEM_BLOCK_SYMBOLS,
+        .trans_queue_depth = 1,
+        .intr_priority = 0,
+        .flags = {
+            .invert_out = 0,
+            .with_dma = 0,
+            .io_loop_back = 0,
+            .io_od_mode = 0,
+            .allow_pd = 0,
+        },
+    };
+
+    ESP_RETURN_ON_ERROR(rmt_new_tx_channel(&tx_chan_cfg, &s_bsp_ir_rmt_channel), TAG,
+                        "failed to create BSP-owned RMT TX channel");
+    ESP_RETURN_ON_ERROR(rmt_enable(s_bsp_ir_rmt_channel), TAG,
+                        "failed to enable BSP-owned RMT TX channel");
+    return ESP_OK;
+}
+
 void app_main(void)
 {
     tvbgone_core_config_t config;
+
+    // Init from the BSP side
     gpio_config_t input_gpio_cfg = {
         .pin_bit_mask = (1ULL << TVBGONE_BUTTON_GPIO),
         .mode = GPIO_MODE_INPUT,
@@ -96,11 +128,17 @@ void app_main(void)
     };
 
     ESP_ERROR_CHECK(gpio_config(&input_gpio_cfg));
+    // Still on the BSP side, we need to initialize the RMT channel that will be used by the component
+    ESP_ERROR_CHECK(dcsg1b_init_bsp_ir_channel());
 
+    // On the component side, we need to set the RMT channel mode to BORROWED and provide the externally initialized channel
     tvbgone_core_get_default_config(&config);
-    config.ir_led_gpio = TVBGONE_IR_LED_GPIO;
+    config.rmt_channel_mode = TVBGONE_CORE_RMT_CHANNEL_MODE_BORROWED;
+    config.external_rmt_channel = s_bsp_ir_rmt_channel;
+    // Now with all the peripheral initialization done, we can initialize the component with the config
     ESP_ERROR_CHECK(tvbgone_core_init(&config));
-
+    // Here we will create a task to pool the button state and trigger sends when it's pressed
+    // Will be also managed by the BSP, so some changes might be needed on the BSP side to fit this in the main application task
     BaseType_t button_task_created = xTaskCreate(dcsg1b_button_task, "tvbg_btn", 3072, NULL, 5, NULL);
     ESP_RETURN_VOID_ON_FALSE(button_task_created == pdPASS, TAG,
                              "failed to create button task");

--- a/tv-b-gone/examples/tvbgone_esp32c3_supermini/README.md
+++ b/tv-b-gone/examples/tvbgone_esp32c3_supermini/README.md
@@ -18,6 +18,8 @@ This project is based on the [TV-B-Gone-kit_V2](https://github.com/maltman23/TV-
 - Press the EU button to transmit the Europe database.
 - Press either button during an active transmission to stop and restart from
   the first code of the newly selected region.
+- This example uses the default internal RMT-channel mode, where
+  `tvbgone_core` creates and owns the TX channel.
 - The example owns button polling and visible LED signaling; the core only
   drives the IR LED.
 

--- a/tv-b-gone/examples/tvbgone_esp32c3_supermini/main/main.c
+++ b/tv-b-gone/examples/tvbgone_esp32c3_supermini/main/main.c
@@ -148,6 +148,7 @@ void app_main(void)
 
     tvbgone_core_get_default_config(&config);
     config.ir_led_gpio = TVBGONE_IR_LED_GPIO;
+    config.rmt_channel_mode = TVBGONE_CORE_RMT_CHANNEL_MODE_INTERNAL;
     ESP_ERROR_CHECK(tvbgone_core_init(&config));
 
     BaseType_t button_task_created = xTaskCreate(button_task, "tvbg_btn", 3072, NULL, 5, NULL);

--- a/tv-b-gone/idf_component.yml
+++ b/tv-b-gone/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.2.0"
+version: "0.3.0"
 description: TV-B-Gone board runtime component for ESP-IDF using the RMT TX peripheral.
 url: https://github.com/pedrominatel/esp-components/tree/main/tv-b-gone
 repository: https://github.com/pedrominatel/esp-components.git

--- a/tv-b-gone/include/tvbgone_core.h
+++ b/tv-b-gone/include/tvbgone_core.h
@@ -3,6 +3,7 @@
 #include <stdint.h>
 
 #include "driver/gpio.h"
+#include "driver/rmt_tx.h"
 #include "esp_err.h"
 #include "freertos/FreeRTOS.h"
 
@@ -25,13 +26,34 @@ typedef enum {
     TVBGONE_CORE_SEND_MODE_CONTINUOUS,
 } tvbgone_core_send_mode_t;
 
+typedef enum {
+    TVBGONE_CORE_RUN_STATE_IDLE = 0,
+    TVBGONE_CORE_RUN_STATE_RUNNING,
+    TVBGONE_CORE_RUN_STATE_STOPPING,
+} tvbgone_core_run_state_t;
+
+typedef enum {
+    TVBGONE_CORE_RMT_CHANNEL_MODE_INTERNAL = 0,
+    TVBGONE_CORE_RMT_CHANNEL_MODE_BORROWED,
+} tvbgone_core_rmt_channel_mode_t;
+
 typedef struct {
     gpio_num_t ir_led_gpio;
     uint32_t task_stack_size;
     UBaseType_t task_priority;
+    tvbgone_core_rmt_channel_mode_t rmt_channel_mode;
+    rmt_channel_handle_t external_rmt_channel;
 } tvbgone_core_config_t;
 
+typedef struct {
+    tvbgone_core_run_state_t run_state;
+    tvbgone_core_region_t region;
+    uint16_t current_code_number;
+    uint16_t total_codes;
+} tvbgone_core_status_t;
+
 void tvbgone_core_get_default_config(tvbgone_core_config_t *config);
+esp_err_t tvbgone_core_get_status(tvbgone_core_status_t *status);
 esp_err_t tvbgone_core_init(const tvbgone_core_config_t *config);
 esp_err_t tvbgone_core_send(tvbgone_core_region_t region, tvbgone_core_send_mode_t mode);
 esp_err_t tvbgone_core_stop(void);

--- a/tv-b-gone/tvbgone_core.c
+++ b/tv-b-gone/tvbgone_core.c
@@ -31,6 +31,7 @@ static const char *TAG = "tvbgone_core";
 #define RMT_MEM_BLOCK_SYMBOLS 128
 #define RMT_MAX_DURATION_TICKS 32767U
 #define RMT_MAX_SYMBOLS 1280U
+
 typedef struct {
     tvbgone_core_config_t config;
     rmt_channel_handle_t ir_rmt_channel;
@@ -42,6 +43,8 @@ typedef struct {
     volatile bool stop_requested;
     tvbgone_core_region_t active_region;
     tvbgone_core_send_mode_t active_mode;
+    uint16_t current_code_number;
+    uint16_t total_codes;
 } tvbgone_core_ctx_t;
 
 static tvbgone_core_ctx_t s_ctx = {
@@ -49,6 +52,8 @@ static tvbgone_core_ctx_t s_ctx = {
         .ir_led_gpio = TVBGONE_CORE_DEFAULT_IRLED_GPIO,
         .task_stack_size = TVBGONE_CORE_DEFAULT_TASK_STACK_SIZE,
         .task_priority = TVBGONE_CORE_DEFAULT_TASK_PRIORITY,
+        .rmt_channel_mode = TVBGONE_CORE_RMT_CHANNEL_MODE_INTERNAL,
+        .external_rmt_channel = NULL,
     },
     .active_region = TVBGONE_CORE_REGION_NA,
     .active_mode = TVBGONE_CORE_SEND_MODE_SINGLE,
@@ -59,6 +64,27 @@ static portMUX_TYPE s_ctx_lock = portMUX_INITIALIZER_UNLOCKED;
 static inline bool tvbgone_stop_requested(void)
 {
     return s_ctx.stop_requested;
+}
+
+static inline bool tvbgone_owns_rmt_channel(void)
+{
+    return s_ctx.config.rmt_channel_mode == TVBGONE_CORE_RMT_CHANNEL_MODE_INTERNAL;
+}
+
+static uint16_t get_total_codes_for_region(tvbgone_core_region_t region)
+{
+    if (region == TVBGONE_CORE_REGION_BOTH) {
+        return (uint16_t)num_NAcodes + (uint16_t)num_EUcodes;
+    }
+
+    return (region == TVBGONE_CORE_REGION_NA) ? (uint16_t)num_NAcodes : (uint16_t)num_EUcodes;
+}
+
+static void set_current_code_number(uint16_t code_number)
+{
+    taskENTER_CRITICAL(&s_ctx_lock);
+    s_ctx.current_code_number = code_number;
+    taskEXIT_CRITICAL(&s_ctx_lock);
 }
 
 static esp_err_t begin_send(tvbgone_core_region_t region, tvbgone_core_send_mode_t mode)
@@ -75,6 +101,8 @@ static esp_err_t begin_send(tvbgone_core_region_t region, tvbgone_core_send_mode
         s_ctx.stop_requested = false;
         s_ctx.active_region = region;
         s_ctx.active_mode = mode;
+        s_ctx.current_code_number = 0;
+        s_ctx.total_codes = get_total_codes_for_region(region);
     }
     taskEXIT_CRITICAL(&s_ctx_lock);
 
@@ -86,6 +114,7 @@ static void finish_send(void)
     taskENTER_CRITICAL(&s_ctx_lock);
     s_ctx.sending = false;
     s_ctx.stop_requested = false;
+    s_ctx.current_code_number = 0;
     s_ctx.task_handle = NULL;
     taskEXIT_CRITICAL(&s_ctx_lock);
 }
@@ -163,6 +192,10 @@ static size_t build_power_code_symbols(rmt_symbol_word_t *symbols, size_t max_sy
 
 static void recover_rmt_channel(void)
 {
+    if (s_ctx.ir_rmt_channel == NULL) {
+        return;
+    }
+
     esp_err_t err = rmt_disable(s_ctx.ir_rmt_channel);
     if ((err != ESP_OK) && (err != ESP_ERR_INVALID_STATE)) {
         ESP_LOGW(TAG, "rmt_disable recovery failed: %s", esp_err_to_name(err));
@@ -250,7 +283,7 @@ static esp_err_t xmit_code_interruptible(uint32_t carrier_freq, int num_pairs,
     return wait_tx_done_interruptible();
 }
 
-static esp_err_t send_region_once(tvbgone_core_region_t region)
+static esp_err_t send_region_once(tvbgone_core_region_t region, uint16_t base_code_number)
 {
     uint8_t num_codes = (region == TVBGONE_CORE_REGION_NA) ? num_NAcodes : num_EUcodes;
     struct IrCode **power_codes = (region == TVBGONE_CORE_REGION_NA) ? NApowerCodes : EUpowerCodes;
@@ -265,6 +298,7 @@ static esp_err_t send_region_once(tvbgone_core_region_t region)
         }
 
         pwr_code_ptr = power_codes[power_code_count];
+        set_current_code_number((uint16_t)(base_code_number + power_code_count + 1));
 
         ESP_LOGI(TAG, "Transmitting %s POWER-Code %d...", region_name, power_code_count);
         ESP_RETURN_ON_ERROR(xmit_code_interruptible(pwr_code_ptr->carrier_freq,
@@ -292,16 +326,16 @@ static esp_err_t send_selected_region(tvbgone_core_region_t region)
              : "BOTH");
 
     if (region == TVBGONE_CORE_REGION_BOTH) {
-        ESP_RETURN_ON_ERROR(send_region_once(TVBGONE_CORE_REGION_NA), TAG,
+        ESP_RETURN_ON_ERROR(send_region_once(TVBGONE_CORE_REGION_NA, 0), TAG,
                             "BOTH send interrupted during NA region");
         ESP_RETURN_ON_ERROR(delay_interruptible(TIME_BETWEEN_CODES_MS), TAG,
                             "BOTH send interrupted between regions");
-        ESP_RETURN_ON_ERROR(send_region_once(TVBGONE_CORE_REGION_EU), TAG,
+        ESP_RETURN_ON_ERROR(send_region_once(TVBGONE_CORE_REGION_EU, num_NAcodes), TAG,
                             "BOTH send interrupted during EU region");
         return ESP_OK;
     }
 
-    return send_region_once(region);
+    return send_region_once(region, 0);
 }
 
 static void tvbgone_continuous_task(void *pv_parameters)
@@ -339,13 +373,36 @@ static esp_err_t init_hardware(void)
         },
     };
     rmt_copy_encoder_config_t copy_encoder_cfg = {};
+    esp_err_t err;
+
+    if (s_ctx.config.rmt_channel_mode == TVBGONE_CORE_RMT_CHANNEL_MODE_BORROWED) {
+        s_ctx.ir_rmt_channel = s_ctx.config.external_rmt_channel;
+        ESP_RETURN_ON_ERROR(rmt_new_copy_encoder(&copy_encoder_cfg, &s_ctx.ir_copy_encoder), TAG,
+                            "failed to create RMT encoder");
+        ESP_LOGI(TAG, "Using externally initialized RMT TX channel");
+        return ESP_OK;
+    }
 
     ESP_RETURN_ON_ERROR(rmt_new_tx_channel(&tx_chan_cfg, &s_ctx.ir_rmt_channel), TAG,
                         "failed to create RMT TX channel");
-    ESP_RETURN_ON_ERROR(rmt_new_copy_encoder(&copy_encoder_cfg, &s_ctx.ir_copy_encoder), TAG,
-                        "failed to create RMT encoder");
-    ESP_RETURN_ON_ERROR(rmt_enable(s_ctx.ir_rmt_channel), TAG,
-                        "failed to enable RMT channel");
+
+    err = rmt_new_copy_encoder(&copy_encoder_cfg, &s_ctx.ir_copy_encoder);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "failed to create RMT encoder: %s", esp_err_to_name(err));
+        rmt_del_channel(s_ctx.ir_rmt_channel);
+        s_ctx.ir_rmt_channel = NULL;
+        return err;
+    }
+
+    err = rmt_enable(s_ctx.ir_rmt_channel);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "failed to enable RMT channel: %s", esp_err_to_name(err));
+        rmt_del_encoder(s_ctx.ir_copy_encoder);
+        rmt_del_channel(s_ctx.ir_rmt_channel);
+        s_ctx.ir_copy_encoder = NULL;
+        s_ctx.ir_rmt_channel = NULL;
+        return err;
+    }
 
     ESP_LOGI(TAG, "TV-B-Gone IR hardware configuration done");
     return ESP_OK;
@@ -357,7 +414,30 @@ void tvbgone_core_get_default_config(tvbgone_core_config_t *config)
         return;
     }
 
-    *config = s_ctx.config;
+    *config = (tvbgone_core_config_t) {
+        .ir_led_gpio = TVBGONE_CORE_DEFAULT_IRLED_GPIO,
+        .task_stack_size = TVBGONE_CORE_DEFAULT_TASK_STACK_SIZE,
+        .task_priority = TVBGONE_CORE_DEFAULT_TASK_PRIORITY,
+        .rmt_channel_mode = TVBGONE_CORE_RMT_CHANNEL_MODE_INTERNAL,
+        .external_rmt_channel = NULL,
+    };
+}
+
+esp_err_t tvbgone_core_get_status(tvbgone_core_status_t *status)
+{
+    ESP_RETURN_ON_FALSE(status != NULL, ESP_ERR_INVALID_ARG, TAG,
+                        "status must not be null");
+
+    taskENTER_CRITICAL(&s_ctx_lock);
+    status->run_state = s_ctx.stop_requested ? TVBGONE_CORE_RUN_STATE_STOPPING
+                        : s_ctx.sending   ? TVBGONE_CORE_RUN_STATE_RUNNING
+                                          : TVBGONE_CORE_RUN_STATE_IDLE;
+    status->region = s_ctx.active_region;
+    status->current_code_number = s_ctx.current_code_number;
+    status->total_codes = s_ctx.total_codes;
+    taskEXIT_CRITICAL(&s_ctx_lock);
+
+    return ESP_OK;
 }
 
 esp_err_t tvbgone_core_init(const tvbgone_core_config_t *config)
@@ -379,8 +459,16 @@ esp_err_t tvbgone_core_init(const tvbgone_core_config_t *config)
 
     ESP_RETURN_ON_FALSE(effective_config.task_stack_size > 0, ESP_ERR_INVALID_ARG, TAG,
                         "task stack size must be greater than zero");
-    ESP_RETURN_ON_FALSE(GPIO_IS_VALID_OUTPUT_GPIO(effective_config.ir_led_gpio),
-                        ESP_ERR_INVALID_ARG, TAG, "invalid IR LED GPIO");
+    ESP_RETURN_ON_FALSE(effective_config.rmt_channel_mode <= TVBGONE_CORE_RMT_CHANNEL_MODE_BORROWED,
+                        ESP_ERR_INVALID_ARG, TAG, "invalid RMT channel mode");
+
+    if (effective_config.rmt_channel_mode == TVBGONE_CORE_RMT_CHANNEL_MODE_INTERNAL) {
+        ESP_RETURN_ON_FALSE(GPIO_IS_VALID_OUTPUT_GPIO(effective_config.ir_led_gpio),
+                            ESP_ERR_INVALID_ARG, TAG, "invalid IR LED GPIO");
+    } else {
+        ESP_RETURN_ON_FALSE(effective_config.external_rmt_channel != NULL,
+                            ESP_ERR_INVALID_ARG, TAG, "external RMT channel must not be null");
+    }
 
     s_ctx.config = effective_config;
     ESP_RETURN_ON_ERROR(init_hardware(), TAG, "failed to initialize hardware");
@@ -457,21 +545,25 @@ esp_err_t tvbgone_core_deinit(void)
     }
 
     if (s_ctx.ir_rmt_channel != NULL) {
-        esp_err_t err = rmt_disable(s_ctx.ir_rmt_channel);
-        if ((err != ESP_OK) && (err != ESP_ERR_INVALID_STATE)) {
-            return err;
-        }
+        if (tvbgone_owns_rmt_channel()) {
+            esp_err_t err = rmt_disable(s_ctx.ir_rmt_channel);
+            if ((err != ESP_OK) && (err != ESP_ERR_INVALID_STATE)) {
+                return err;
+            }
 
-        ESP_RETURN_ON_ERROR(rmt_del_channel(s_ctx.ir_rmt_channel), TAG,
-                            "failed to delete RMT channel");
+            ESP_RETURN_ON_ERROR(rmt_del_channel(s_ctx.ir_rmt_channel), TAG,
+                                "failed to delete RMT channel");
+        }
         s_ctx.ir_rmt_channel = NULL;
     }
 
     taskENTER_CRITICAL(&s_ctx_lock);
+    tvbgone_core_get_default_config(&s_ctx.config);
     s_ctx.initialized = false;
     s_ctx.stop_requested = false;
-    s_ctx.active_region = TVBGONE_CORE_REGION_NA;
     s_ctx.active_mode = TVBGONE_CORE_SEND_MODE_SINGLE;
+    s_ctx.current_code_number = 0;
+    s_ctx.total_codes = 0;
     taskEXIT_CRITICAL(&s_ctx_lock);
 
     return ESP_OK;


### PR DESCRIPTION
  - add optional borrowed RMT TX channel support to `tvbgone_core`
  - keep the existing internal/self-owned RMT initialization path as the default
  - update docs and examples to show both ownership modes